### PR TITLE
Handle PDF parsing exceptions

### DIFF
--- a/src/python/paperetl/analysis.py
+++ b/src/python/paperetl/analysis.py
@@ -57,6 +57,10 @@ class Study(object):
             study design fields as tuple
         """
 
+        # Return default values if sections is empty
+        if not sections:
+            return (0, None, None, None, [])
+
         # Get design models
         attribute, design = getModels(models)
 

--- a/src/python/paperetl/file/execute.py
+++ b/src/python/paperetl/file/execute.py
@@ -8,7 +8,6 @@ from ..factory import Factory
 from .pdf import PDF
 from .tei import TEI
 
-
 class Execute(object):
     """
     Transforms and loads medical/scientific files into an articles database.
@@ -44,17 +43,11 @@ class Execute(object):
                     print("Processing: %s" % path)
                     with open(path, "rb" if isPdf else "r") as data:
                         # Parse article
-                        try:
-                            article = (
-                                PDF.parse(data, f, models)
-                                if isPdf
-                                else TEI.parse(data, f, models)
-                            )
-                        except ValueError:
-                            # Catches sklearn validation error
-                            # https://gist.github.com/nialov/6c337c748908f5d07d550114b5f0965a
-                            print(f"Failed to parse: {f}")
-                            continue
+                        article = (
+                            PDF.parse(data, f, models)
+                            if isPdf
+                            else TEI.parse(data, f, models)
+                        )
 
                         # Save article if unique
                         if article.uid() not in ids:

--- a/src/python/paperetl/file/execute.py
+++ b/src/python/paperetl/file/execute.py
@@ -8,6 +8,7 @@ from ..factory import Factory
 from .pdf import PDF
 from .tei import TEI
 
+
 class Execute(object):
     """
     Transforms and loads medical/scientific files into an articles database.
@@ -43,7 +44,17 @@ class Execute(object):
                     print("Processing: %s" % path)
                     with open(path, "rb" if isPdf else "r") as data:
                         # Parse article
-                        article = PDF.parse(data, f, models) if isPdf else TEI.parse(data, f, models)
+                        try:
+                            article = (
+                                PDF.parse(data, f, models)
+                                if isPdf
+                                else TEI.parse(data, f, models)
+                            )
+                        except ValueError:
+                            # Catches sklearn validation error
+                            # https://gist.github.com/nialov/6c337c748908f5d07d550114b5f0965a
+                            print(f"Failed to parse: {f}")
+                            continue
 
                         # Save article if unique
                         if article.uid() not in ids:

--- a/src/python/paperetl/file/execute.py
+++ b/src/python/paperetl/file/execute.py
@@ -46,7 +46,7 @@ class Execute(object):
                         article = PDF.parse(data, f, models) if isPdf else TEI.parse(data, f, models)
 
                         # Save article if unique
-                        if article.uid() not in ids:
+                        if article and article.uid() not in ids:
                             db.save(article)
                             ids.add(article.uid())
 

--- a/src/python/paperetl/file/execute.py
+++ b/src/python/paperetl/file/execute.py
@@ -43,11 +43,7 @@ class Execute(object):
                     print("Processing: %s" % path)
                     with open(path, "rb" if isPdf else "r") as data:
                         # Parse article
-                        article = (
-                            PDF.parse(data, f, models)
-                            if isPdf
-                            else TEI.parse(data, f, models)
-                        )
+                        article = PDF.parse(data, f, models) if isPdf else TEI.parse(data, f, models)
 
                         # Save article if unique
                         if article.uid() not in ids:

--- a/src/python/paperetl/file/pdf.py
+++ b/src/python/paperetl/file/pdf.py
@@ -27,8 +27,11 @@ class PDF(object):
             (uid, article metadata, section text, article tags, study design)
         """
 
-        # Convert PDF stream to TEI XML, parse and return object
-        return TEI.parse(PDF.convert(stream), source, models)
+        # Attempt to convert PDF to TEI XML
+        xml = PDF.convert(stream)
+
+        # Parse and return object
+        return TEI.parse(xml, source, models) if xml else None
 
     @staticmethod
     def convert(stream):
@@ -43,7 +46,12 @@ class PDF(object):
         """
 
         # Call GROBID API
-        data = requests.post("http://localhost:8070/api/processFulltextDocument", files={"input": stream}).text
+        response = requests.post("http://localhost:8070/api/processFulltextDocument", files={"input": stream})
+
+        # Validate request was successful
+        if not response.ok:
+            print("Failed to process file - %s" % (response.text))
+            return None
 
         # Wrap as StringIO
-        return StringIO(data)
+        return StringIO(response.text)

--- a/src/python/paperetl/file/tei.py
+++ b/src/python/paperetl/file/tei.py
@@ -176,6 +176,8 @@ class TEI(object):
                     append_text = str(e.text)
                     text_appends.append(append_text)
                 except AttributeError:
+                    # 'NavigableString' object has no attribute 'text'
+                    # https://gist.github.com/nialov/1317461ae74719b765219d22c4cd4ba2
                     continue
             text = " ".join(text_appends)
 

--- a/src/python/paperetl/file/tei.py
+++ b/src/python/paperetl/file/tei.py
@@ -19,7 +19,6 @@ from ..text import Text
 # pylint: disable=W0603
 GRAMMAR = None
 
-
 def getGrammar():
     """
     Multiprocessing helper method. Gets (or first creates then gets) a global grammar object to
@@ -35,7 +34,6 @@ def getGrammar():
         GRAMMAR = Grammar()
 
     return GRAMMAR
-
 
 class TEI(object):
     """
@@ -57,11 +55,7 @@ class TEI(object):
         # Parse publication date
         # pylint: disable=W0702
         try:
-            published = (
-                parser.parse(published["when"])
-                if published and "when" in published.attrs
-                else None
-            )
+            published = parser.parse(published["when"]) if published and "when" in published.attrs else None
         except:
             published = None
 
@@ -113,11 +107,7 @@ class TEI(object):
             authors = TEI.authors(source)
 
             struct = soup.find("biblstruct")
-            reference = (
-                "https://doi.org/" + struct.find("idno").text
-                if struct and struct.find("idno")
-                else None
-            )
+            reference = "https://doi.org/" + struct.find("idno").text if struct and struct.find("idno") else None
         else:
             published, publication, authors, reference = None, None, None, None
 
@@ -165,9 +155,6 @@ class TEI(object):
 
         # Initialize with title and abstract text
         sections = TEI.abstract(soup, title)
-
-        if soup.find("text") is None:
-            return sections
 
         for section in soup.find("text").find_all("div", recursive=False):
             # Section name and text
@@ -243,20 +230,13 @@ class TEI(object):
         tokenslist = grammar.parse([text for _, text in sections])
 
         # Join NLP tokens with sections
-        sections = [
-            (name, text, tokenslist[x])
-            for x, (name, text) in enumerate(sections)
-            if tokenslist[x]
-        ]
+        sections = [(name, text, tokenslist[x]) for x, (name, text) in enumerate(sections) if tokenslist[x]]
 
         # Parse study design fields
         design, size, sample, method, labels = Study.parse(sections, models)
 
         # Add additional fields to each section
-        sections = [
-            (name, text, labels[x] if labels[x] else grammar.label(tokens))
-            for x, (name, text, tokens) in enumerate(sections)
-        ]
+        sections = [(name, text, labels[x] if labels[x] else grammar.label(tokens)) for x, (name, text, tokens) in enumerate(sections)]
 
         # Derive uid
         try:
@@ -271,20 +251,7 @@ class TEI(object):
 
         # Article metadata - id, source, published, publication, authors, title, tags, design, sample size
         #                    sample section, sample method, reference, entry date
-        metadata = (
-            uid,
-            source,
-            published,
-            publication,
-            authors,
-            title,
-            "PDF",
-            design,
-            size,
-            sample,
-            method,
-            reference,
-            datetime.datetime.now().strftime("%Y-%m-%d"),
-        )
+        metadata = (uid, source, published, publication, authors, title, "PDF", design, size,
+                    sample, method, reference, datetime.datetime.now().strftime("%Y-%m-%d"))
 
         return Article(metadata, sections, source)

--- a/src/python/paperetl/file/tei.py
+++ b/src/python/paperetl/file/tei.py
@@ -128,9 +128,7 @@ class TEI(object):
 
         sections = [("TITLE", title)]
 
-        abstract = (
-            soup.find("abstract").text if soup.find("abstract") is not None else ""
-        )
+        abstract = soup.find("abstract").text if soup.find("abstract") is not None else ""
         if abstract:
             # Transform and clean text
             abstract = Text.transform(abstract)
@@ -156,9 +154,8 @@ class TEI(object):
         # Initialize with title and abstract text
         sections = TEI.abstract(soup, title)
 
-        # Verify that BeautifulSoup object has findable 'text'
-        found_texts = soup.find("text")
-        if not hasattr(found_texts, "text"):
+        # Verify that BeautifulSoup object is not None and has find_all method
+        if not hasattr(soup.find("text"), "find_all"):
             return sections
 
         for section in soup.find("text").find_all("div", recursive=False):

--- a/src/python/paperetl/file/tei.py
+++ b/src/python/paperetl/file/tei.py
@@ -159,7 +159,7 @@ class TEI(object):
             children = list(section.children)
 
             # Attempt to parse section header
-            if len(children) > 1 and not children[0].name:
+            if children and not children[0].name:
                 name = str(children[0]).upper()
                 children = children[1:]
             else:

--- a/src/python/paperetl/study/design.py
+++ b/src/python/paperetl/study/design.py
@@ -29,6 +29,7 @@ from sklearn.ensemble import RandomForestClassifier
 from .study import StudyModel
 from .vocab import Vocab
 
+
 class Design(StudyModel):
     """
     Prediction model used to classify study designs.
@@ -55,13 +56,17 @@ class Design(StudyModel):
         return int(self.model.predict(features)[0])
 
     def create(self):
-        return RandomForestClassifier(n_estimators=129, max_depth=21, max_features=0.22, random_state=0)
+        return RandomForestClassifier(
+            n_estimators=129, max_depth=21, max_features=0.22, random_state=0
+        )
 
     def hyperparams(self):
-        return {"n_estimators": range(125, 150),
-                "max_depth": range(20, 30),
-                "max_features": [x / 100 for x in range(15, 25)],
-                "random_state": (0,)}
+        return {
+            "n_estimators": range(125, 150),
+            "max_depth": range(20, 30),
+            "max_features": [x / 100 for x in range(15, 25)],
+            "random_state": (0,),
+        }
 
     def data(self, training):
         # Unique ids
@@ -84,7 +89,11 @@ class Design(StudyModel):
             # Build id list for each uid batch
             for idlist in self.batch(list(uids.keys()), 999):
                 # Get section text and transform to features
-                cur.execute("SELECT name, text, article FROM sections WHERE article in (%s) ORDER BY id" % ",".join(["?"] * len(idlist)), idlist)
+                cur.execute(
+                    "SELECT name, text, article FROM sections WHERE article in (%s) ORDER BY id"
+                    % ",".join(["?"] * len(idlist)),
+                    idlist,
+                )
                 i, f, l = self.transform(cur.fetchall(), uids)
 
                 # Combine lists from each batch
@@ -108,7 +117,7 @@ class Design(StudyModel):
             list of lists split into batch size
         """
 
-        return [uids[x:x + size] for x in range(0, len(uids), size)]
+        return [uids[x : x + size] for x in range(0, len(uids), size)]
 
     def transform(self, rows, uids):
         """
@@ -157,18 +166,35 @@ class Design(StudyModel):
         title = title[0].lower() if title else None
 
         for keyword in Vocab.TITLE:
-            vector.append(len(re.findall("\\b%s\\b" % keyword.lower(), title)) if title else 0)
+            vector.append(
+                len(re.findall("\\b%s\\b" % keyword.lower(), title)) if title else 0
+            )
 
         # Build full text from filtered sections
-        text = [text for name, text, _ in sections if not name or StudyModel.filter(name.lower())]
+        text = [
+            text
+            for name, text, _ in sections
+            if not name or StudyModel.filter(name.lower())
+        ]
         text = " ".join(text).replace("\n", " ").lower()
 
         # Get token length across filtered sections
-        length = sum([len(tokens) for name, _, tokens in sections if not name or StudyModel.filter(name.lower())])
+        length = sum(
+            [
+                len(tokens)
+                for name, _, tokens in sections
+                if not name or StudyModel.filter(name.lower())
+            ]
+        )
 
         # Add study design term counts normalized by document length
         for keyword in self.keywords:
-            vector.append(len(re.findall("\\b%s\\b" % keyword.lower(), text)) / length)
+            if length != 0:
+                vector.append(
+                    len(re.findall("\\b%s\\b" % keyword.lower(), text)) / length
+                )
+            else:
+                vector.append(1)
 
         return vector
 
@@ -198,7 +224,10 @@ class Design(StudyModel):
         finally:
             db.close()
 
+
 if __name__ == "__main__":
-    Design.run(sys.argv[1] if len(sys.argv) > 1 else None,
-               sys.argv[2] if len(sys.argv) > 2 else None,
-               sys.argv[3] == "1" if len(sys.argv) > 3 else False)
+    Design.run(
+        sys.argv[1] if len(sys.argv) > 1 else None,
+        sys.argv[2] if len(sys.argv) > 2 else None,
+        sys.argv[3] == "1" if len(sys.argv) > 3 else False,
+    )

--- a/src/python/paperetl/study/design.py
+++ b/src/python/paperetl/study/design.py
@@ -168,12 +168,7 @@ class Design(StudyModel):
 
         # Add study design term counts normalized by document length
         for keyword in self.keywords:
-            if length != 0:
-                vector.append(
-                    len(re.findall("\\b%s\\b" % keyword.lower(), text)) / length
-                )
-            else:
-                vector.append(1)
+            vector.append(len(re.findall("\\b%s\\b" % keyword.lower(), text)) / length)
 
         return vector
 

--- a/src/python/paperetl/study/design.py
+++ b/src/python/paperetl/study/design.py
@@ -29,7 +29,6 @@ from sklearn.ensemble import RandomForestClassifier
 from .study import StudyModel
 from .vocab import Vocab
 
-
 class Design(StudyModel):
     """
     Prediction model used to classify study designs.
@@ -56,17 +55,13 @@ class Design(StudyModel):
         return int(self.model.predict(features)[0])
 
     def create(self):
-        return RandomForestClassifier(
-            n_estimators=129, max_depth=21, max_features=0.22, random_state=0
-        )
+        return RandomForestClassifier(n_estimators=129, max_depth=21, max_features=0.22, random_state=0)
 
     def hyperparams(self):
-        return {
-            "n_estimators": range(125, 150),
-            "max_depth": range(20, 30),
-            "max_features": [x / 100 for x in range(15, 25)],
-            "random_state": (0,),
-        }
+        return {"n_estimators": range(125, 150),
+                "max_depth": range(20, 30),
+                "max_features": [x / 100 for x in range(15, 25)],
+                "random_state": (0,)}
 
     def data(self, training):
         # Unique ids
@@ -89,11 +84,7 @@ class Design(StudyModel):
             # Build id list for each uid batch
             for idlist in self.batch(list(uids.keys()), 999):
                 # Get section text and transform to features
-                cur.execute(
-                    "SELECT name, text, article FROM sections WHERE article in (%s) ORDER BY id"
-                    % ",".join(["?"] * len(idlist)),
-                    idlist,
-                )
+                cur.execute("SELECT name, text, article FROM sections WHERE article in (%s) ORDER BY id" % ",".join(["?"] * len(idlist)), idlist)
                 i, f, l = self.transform(cur.fetchall(), uids)
 
                 # Combine lists from each batch
@@ -117,7 +108,7 @@ class Design(StudyModel):
             list of lists split into batch size
         """
 
-        return [uids[x : x + size] for x in range(0, len(uids), size)]
+        return [uids[x:x + size] for x in range(0, len(uids), size)]
 
     def transform(self, rows, uids):
         """
@@ -166,26 +157,14 @@ class Design(StudyModel):
         title = title[0].lower() if title else None
 
         for keyword in Vocab.TITLE:
-            vector.append(
-                len(re.findall("\\b%s\\b" % keyword.lower(), title)) if title else 0
-            )
+            vector.append(len(re.findall("\\b%s\\b" % keyword.lower(), title)) if title else 0)
 
         # Build full text from filtered sections
-        text = [
-            text
-            for name, text, _ in sections
-            if not name or StudyModel.filter(name.lower())
-        ]
+        text = [text for name, text, _ in sections if not name or StudyModel.filter(name.lower())]
         text = " ".join(text).replace("\n", " ").lower()
 
         # Get token length across filtered sections
-        length = sum(
-            [
-                len(tokens)
-                for name, _, tokens in sections
-                if not name or StudyModel.filter(name.lower())
-            ]
-        )
+        length = sum([len(tokens) for name, _, tokens in sections if not name or StudyModel.filter(name.lower())])
 
         # Add study design term counts normalized by document length
         for keyword in self.keywords:
@@ -224,10 +203,7 @@ class Design(StudyModel):
         finally:
             db.close()
 
-
 if __name__ == "__main__":
-    Design.run(
-        sys.argv[1] if len(sys.argv) > 1 else None,
-        sys.argv[2] if len(sys.argv) > 2 else None,
-        sys.argv[3] == "1" if len(sys.argv) > 3 else False,
-    )
+    Design.run(sys.argv[1] if len(sys.argv) > 1 else None,
+               sys.argv[2] if len(sys.argv) > 2 else None,
+               sys.argv[3] == "1" if len(sys.argv) > 3 else False)


### PR DESCRIPTION
I created an `articles.sqlite` from some older/varying academic article PDFs which probably had faulty/lacking metadata and which were probably invalidly parsed by GROBID. I was able to run almost all PDFs with the changes proposed in this pull request and if the PDF parsing completely failed, I added a `try-except`-clause in `src/python/paperetl/file/execute.py` which catched the [exception](https://gist.github.com/nialov/6c337c748908f5d07d550114b5f0965a).

Most exceptions are caused by `None` `AttributeErrors` returned from BeautifulSoup finds/title-attributes. I made gists of other errors:

* [`ValueError` catched in `execute.py`](https://gist.github.com/nialov/6c337c748908f5d07d550114b5f0965a)
* [`AttributeError` catched in `tei.py`](https://gist.github.com/nialov/1317461ae74719b765219d22c4cd4ba2)

The changes in ` src/python/paperetl/study/design.py` might not be necessary (and I wasn't really sure of what I was doing.) The same error is caught by the `try-except`-clause in `src/python/paperetl/file/execute.py`. Could just alternatively raise a `ValueError` when length is zero.

In `tei.py` I used `source` as alternative for `title` when `title` was not parsed. Might be ok when articles are anyway uniquely named?

