### PR TITLE
Use figure index rather than xml:id attribute this is not always present

### DIFF
--- a/src/python/paperetl/file/tei.py
+++ b/src/python/paperetl/file/tei.py
@@ -243,8 +243,9 @@ class TEI:
 
         # Extract text from tables
         for i, figure in enumerate(soup.find("text").find_all("figure")):
-            # index as figure name to ensure figures are uniquely named
-            name = f"FIGURE_{i}"
+            # Use XML Id (if available) as figure name to ensure figures are uniquely named
+            name = figure.get("xml:id")
+            name = name.upper() if name else f"FIGURE_{i}"
 
             # Search for table
             table = figure.find("table")

--- a/src/python/paperetl/file/tei.py
+++ b/src/python/paperetl/file/tei.py
@@ -242,9 +242,9 @@ class TEI:
             sections.extend([(name, x) for x in sent_tokenize(text)])
 
         # Extract text from tables
-        for figure in soup.find("text").find_all("figure"):
-            # Use XML Id as figure name to ensure figures are uniquely named
-            name = figure.get("xml:id").upper()
+        for i, figure in enumerate(soup.find("text").find_all("figure")):
+            # index as figure name to ensure figures are uniquely named
+            name = f"FIGURE_{i}"
 
             # Search for table
             table = figure.find("table")


### PR DESCRIPTION

This is particularly  true when loading papers which are parsed from PDFs e.g #46 

If this just needs to be unique within the scope of the document, then perhaps we can use an index instead.